### PR TITLE
Fix for PreparedStatement parameter setting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/teradata-driver "1.0.0-metabase-v0.34.1-teradata-jdbc-16.20"
+(defproject metabase/teradata-driver "1.0.1-metabase-v0.34.1-teradata-jdbc-16.20"
   :min-lein-version "2.5.0"
 
   :profiles

--- a/src/metabase/driver/teradata.clj
+++ b/src/metabase/driver/teradata.clj
@@ -18,10 +18,9 @@
             [metabase.query-processor.util :as qputil]
             [metabase.util
              [honeysql-extensions :as hx]])
-  (:import [java.sql DatabaseMetaData ResultSet Types]
+  (:import [java.sql DatabaseMetaData ResultSet Types PreparedStatement]
            [java.time OffsetDateTime OffsetTime]
-           [java.util Calendar TimeZone]
-           [java.sql PreparedStatement]))
+           [java.util Calendar TimeZone]))
 
 (driver/register! :teradata, :parent :sql-jdbc)
 

--- a/src/metabase/driver/teradata.clj
+++ b/src/metabase/driver/teradata.clj
@@ -4,6 +4,7 @@
              [string :as s]]
             [clojure.java.jdbc :as jdbc]
             [honeysql.core :as hsql]
+            [java-time :as t]
             [metabase
              [driver :as driver]
              [util :as u]]
@@ -14,13 +15,13 @@
              [sync :as sql-jdbc.sync]]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.deduplicate :as deduplicateutil]
-            [metabase.models.field :as field]
             [metabase.query-processor.util :as qputil]
             [metabase.util
-             [honeysql-extensions :as hx]
-             [ssh :as ssh]])
-  (:import [java.sql DatabaseMetaData ResultSet ResultSetMetaData Time Types]
-           [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
+             [honeysql-extensions :as hx]])
+  (:import [java.sql DatabaseMetaData ResultSet Types]
+           [java.time OffsetDateTime OffsetTime]
+           [java.util Calendar TimeZone]
+           [java.sql PreparedStatement]))
 
 (driver/register! :teradata, :parent :sql-jdbc)
 
@@ -248,6 +249,13 @@
 (defmethod sql-jdbc.execute/read-column [:teradata Types/TIME_WITH_TIMEZONE]
            [_ _ rs _ i]
            (OffsetTime/parse (.getTime rs i)))
+
+;; TODO: use metabase.driver.sql-jdbc.execute.legacy-impl instead of re-implementing everything here
+(defmethod sql-jdbc.execute/set-parameter [:teradata OffsetDateTime]
+  [_ ^PreparedStatement ps ^Integer i t]
+  (let [cal (Calendar/getInstance (TimeZone/getTimeZone (t/zone-id t)))
+        t   (t/sql-timestamp t)]
+    (.setTimestamp ps i t cal)))
 
 (defn- run-query
   "Run the query itself without setting the timezone connection parameter as this must not be changed on a Teradata connection.


### PR DESCRIPTION
The Teradata 16.20 JDBC driver is 4.0, but Metabase expects 4.3,
so here we are - back in the times before java.time.
We will either have to override the relevant set-parameter
functions same way as the read-column functions or use
the legacy implementation of sql-jdbc.execute.